### PR TITLE
Update API user list and permissions

### DIFF
--- a/book_lovers/my_books/APIUrls.py
+++ b/book_lovers/my_books/APIUrls.py
@@ -10,15 +10,12 @@ router.register(r'books', APIViews.BookViewSet)
 router.register(r'popularbooks', APIViews.PopularBookViewSet)
 router.register(r'authors',APIViews.AuthorViewSet)
 router.register(r'publishers', APIViews.PublisherViewSet)
-router.register(r'users',APIViews.UserViewSet)
+router.register(r'users',APIViews.UserViewSet,'list')
 
 
 
 urlpatterns = [
                 url(r'^docs/', schema_view),
-                url(r'bookdetail/(?P<pk>\d+)/$',APIViews.BookDetailView.as_view()),
-                url(r'pubdetail/(?P<pk>\d+)/$',APIViews.PubDetailView.as_view()),
-                url(r'authordetail/(?P<pk>\d+)/$',APIViews.AuthorDetailView.as_view()),
                 url(r'books2/',APIViews.BookList2.as_view()),
 ]
 urlpatterns += router.urls

--- a/book_lovers/my_books/APIViews.py
+++ b/book_lovers/my_books/APIViews.py
@@ -52,10 +52,10 @@ class BookViewSet(viewsets.ModelViewSet):
 #         return filter  # Lookup the object
 
 
-class BookDetailView(generics.RetrieveUpdateDestroyAPIView):
-    queryset = Book.objects.all()
-    serializer_class = BookSerializer
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
+#class BookDetailView(generics.RetrieveUpdateDestroyAPIView):
+    #queryset = Book.objects.all()
+    #serializer_class = BookSerializer
+    #permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 
 #display only the books with at least 2 users who favorite
 class PopularBookViewSet(viewsets.ModelViewSet):
@@ -69,30 +69,37 @@ class PopularBookViewSet(viewsets.ModelViewSet):
 class BookList2(generics.ListCreateAPIView):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
-    
 
-class UserViewSet(viewsets.ReadOnlyModelViewSet):
+#a permission designed for UserViewSet -- only staff can see a list of all users. And only staff or the user itself can view a user detail page   
+class IsStaffOrTargetUser(permissions.BasePermission):
+    def has_permission(self, request, view):
+        # allow user to list all users if logged in user is staff
+        return view.action == 'retrieve' or request.user.is_staff 
+ 
+    def has_object_permission(self, request, view, obj):
+        # allow logged in user to view own details, allows staff to view all records
+        return request.user.is_staff or obj == request.user
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    model = User
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    permission_classes = (IsStaffOrTargetUser,)
     
 
 class AuthorViewSet(viewsets.ModelViewSet): #author list - authors can be created here
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
-    permission_class = (permissions.IsAuthenticatedOrReadOnly,)
-
-class AuthorDetailView(generics.RetrieveUpdateDestroyAPIView): #edit individual authors
-    queryset = Author.objects.all()
-    serializer_class = AuthorSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
-       
+
 class PublisherViewSet(viewsets.ModelViewSet): #publisher list - publishers can be created here
     queryset = Publisher.objects.all()
     serializer_class = PublisherSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 
-class PubDetailView(generics.RetrieveUpdateDestroyAPIView): #edit individual publishers
-    queryset = Publisher.objects.all()
-    serializer_class = PublisherSerializer
-    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
+#class PubDetailView(generics.RetrieveUpdateDestroyAPIView): #edit individual publishers
+    #queryset = Publisher.objects.all()
+    #serializer_class = PublisherSerializer
+    #permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 

--- a/book_lovers/my_books/models.py
+++ b/book_lovers/my_books/models.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 
 class Book(models.Model):
-    owner = models.ForeignKey(settings.AUTH_USER_MODEL,null = True, related_name = 'owned_books')
+    owner = models.ForeignKey(settings.AUTH_USER_MODEL, null = True, related_name = 'owned_books')
     title = models.CharField(max_length= 100)
     author = models.ManyToManyField('Author')  # one or more authors per book
     publisher = models.ForeignKey('Publisher', null=True)  # allows for unknown publisher

--- a/book_lovers/my_books/serializers.py
+++ b/book_lovers/my_books/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import Book,Author,Publisher,Tag
 from django.contrib.auth.models import User
+from django.contrib.auth.hashers import make_password
 from django.db import models
 
 
@@ -34,11 +35,17 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('username','email', 'owned_books', 'fav_books')
-        write_only_fields = ('password')
+        write_only_fields = ('password',)
         # extra_kwargs = {
         #     'owned_books':{'write_only':True},
         #     #'my_owned_books':{'write_only':True}
-        #     }
+    def perform_create(self, **validated_data):
+        # call set_password on user object. Without this
+        # the password will be stored in plain text.
+        user = User.objects.create(**validated_data)
+       # user.save(password = make_password(validated_data['password']))
+        return user
+       
 
 class PublisherSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
Fix bugs in the previous user permissions. Now, admin users only are
able to access the list of all Users; users can each access their own
individual detail page.
Also removed the author, book, and publisher detail pages - because all
of the functionality is already built into the ViewSets